### PR TITLE
Generic fix to be same as hamcrest assert signature

### DIFF
--- a/htmlelements-matchers/src/main/java/ru/yandex/qatools/htmlelements/matchers/RefreshMatcherDecorator.java
+++ b/htmlelements-matchers/src/main/java/ru/yandex/qatools/htmlelements/matchers/RefreshMatcherDecorator.java
@@ -15,7 +15,7 @@ import org.openqa.selenium.WebDriver;
 public class RefreshMatcherDecorator<T> extends TypeSafeMatcher<T> {
 
     private WebDriver driver;
-    private Matcher<? extends T> matcher;
+    private Matcher<? super T> matcher;
 
 
     @Override
@@ -24,7 +24,7 @@ public class RefreshMatcherDecorator<T> extends TypeSafeMatcher<T> {
         return matcher.matches(item);
     }
 
-    public RefreshMatcherDecorator(Matcher<? extends T> matcher, WebDriver driver) {
+    public RefreshMatcherDecorator(Matcher<? super T> matcher, WebDriver driver) {
         this.driver = driver;
         this.matcher = matcher;
     }
@@ -44,7 +44,7 @@ public class RefreshMatcherDecorator<T> extends TypeSafeMatcher<T> {
 
 
     @Factory
-    public static <T> Matcher<T> withPrerefresh(Matcher<? extends T> matcher, WebDriver driver) {
+    public static <T> Matcher<? super T> withPrerefresh(Matcher<? super T> matcher, WebDriver driver) {
         return new RefreshMatcherDecorator<T>(matcher, driver);
     }
 

--- a/htmlelements-matchers/src/main/java/ru/yandex/qatools/htmlelements/matchers/WaitForMatcherDecorator.java
+++ b/htmlelements-matchers/src/main/java/ru/yandex/qatools/htmlelements/matchers/WaitForMatcherDecorator.java
@@ -21,12 +21,12 @@ public class WaitForMatcherDecorator<T> extends TypeSafeMatcher<T> {
     public static final long DEFAULT_INTERVAL = MILLISECONDS.toMillis(500);
     public static final long DEFAULT_TIMEOUT = SECONDS.toMillis(30);
 
-    private Matcher<? extends T> matcher;
+    private Matcher<? super T> matcher;
 
     private long timeoutInMilliseconds;
     private long intervalInMilliseconds;
 
-    public WaitForMatcherDecorator(Matcher<? extends T> matcher,
+    public WaitForMatcherDecorator(Matcher<? super T> matcher,
                                    long timeoutInMilliseconds,
                                    long intervalInMilliseconds) {
         this.matcher = matcher;
@@ -65,19 +65,19 @@ public class WaitForMatcherDecorator<T> extends TypeSafeMatcher<T> {
     }
 
     @Factory
-    public static <T> Matcher<T> withWaitFor(Matcher<? extends T> matcher) {
+    public static <T> Matcher<? super T> withWaitFor(Matcher<? super T> matcher) {
         return new WaitForMatcherDecorator<T>(matcher, DEFAULT_TIMEOUT, DEFAULT_INTERVAL);
     }
 
 
     @Factory
-    public static <T> Matcher<T> withWaitFor(Matcher<? extends T> matcher, long timeoutInMilliseconds) {
+    public static <T> Matcher<? super T> withWaitFor(Matcher<? super T> matcher, long timeoutInMilliseconds) {
         return new WaitForMatcherDecorator<T>(matcher, timeoutInMilliseconds, DEFAULT_INTERVAL);
     }
 
 
     @Factory
-    public static <T> Matcher<T> withWaitFor(Matcher<? extends T> matcher,
+    public static <T> Matcher<? super T> withWaitFor(Matcher<? super T> matcher,
                                              long timeoutInMilliseconds,
                                              long intervalInMilliseconds) {
         return new WaitForMatcherDecorator<T>(matcher, timeoutInMilliseconds, intervalInMilliseconds);


### PR DESCRIPTION
generic type fix to be same as hamcrest assertThat(T, Matcher<? super T>) signature

https://github.com/hamcrest/JavaHamcrest/blob/master/hamcrest-core/src/main/java/org/hamcrest/MatcherAssert.java#L11

In this commit https://github.com/hamcrest/JavaHamcrest/commit/a6b00c4aadae733236e481fa747d5223cc7b7a9a#hamcrest-core/src/main/java/org/hamcrest/MatcherAssert.java they change generic same way
