### PR TITLE
Form.fill() doesn't clear text inputs before calling sendKeys()

### DIFF
--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/TextInput.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/TextInput.java
@@ -1,5 +1,7 @@
 package ru.yandex.qatools.htmlelements.element;
 
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 /**
@@ -37,8 +39,8 @@ public class TextInput extends TypifiedElement {
     /**
      * @return Text entered into the text input.
      * @deprecated Use getText() instead.
-     *             <p/>
-     *             Retrieves the text entered into this text input.
+     * <p/>
+     * Retrieves the text entered into this text input.
      */
     @Deprecated
     public String getEnteredText() {
@@ -60,5 +62,14 @@ public class TextInput extends TypifiedElement {
             return "";
         }
         return enteredText;
+    }
+
+    /**
+     * Returns sequence of backspaces and deletes that will clear element.
+     * clear() can't be used because generates separate onchange event
+     * See https://github.com/yandex-qatools/htmlelements/issues/65
+     */
+    public String getClearCharSequence() {
+        return StringUtils.repeat(Keys.DELETE.toString() + Keys.BACK_SPACE, getText().length());
     }
 }

--- a/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/FormFillingTest.java
+++ b/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/FormFillingTest.java
@@ -1,6 +1,5 @@
 package ru.yandex.qatools.htmlelements;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
 import ru.yandex.qatools.htmlelements.testelements.MockedForm;
@@ -21,7 +20,6 @@ public class FormFillingTest {
 
     private final MockedForm form = new MockedForm();
 
-    @Before
     public void fillForm() {
         // Prepare data to fill form with
         Map<String, Object> data = new HashMap<String, Object>();
@@ -39,6 +37,7 @@ public class FormFillingTest {
 
     @Test
     public void formFieldsShouldBeFilledCorrectly() {
+        fillForm();
         verify(form.getTextInput()).sendKeys(INPUT_TEXT_TO_SEND);
         verify(form.getTextInputWithText()).sendKeys(INPUT_WITH_TEXT_KEYS_TO_SEND);
         verify(form.getCheckBox()).click();
@@ -46,5 +45,13 @@ public class FormFillingTest {
         verify(form.getSelectOption()).click();
         verify(form.getTextArea()).sendKeys(INPUT_TEXT_TO_SEND);
         verify(form.getTextAreaWithText()).sendKeys(INPUT_WITH_TEXT_KEYS_TO_SEND);
+    }
+
+    @Test
+    public void clearingFieldWhenNullIsPassed() {
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put(MockedForm.TEXT_INPUT_WITH_TEXT_NAME, null);
+        form.fill(data);
+        verify(form.getTextInputWithText()).sendKeys(Keys.DELETE.toString() + Keys.BACK_SPACE.toString());
     }
 }

--- a/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/testelements/MockedForm.java
+++ b/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/testelements/MockedForm.java
@@ -59,7 +59,7 @@ public class MockedForm extends Form {
     private WebElement mockTextInput(String name, String text) {
         WebElement textInput = mockInputWithNameAndType(name, "text");
         when(getWrappedElement().findElements(By.name(name))).thenReturn(Arrays.asList(textInput));
-        when(textInput.getText()).thenReturn(text);
+        when(textInput.getAttribute("value")).thenReturn(text);
         return textInput;
     }
 


### PR DESCRIPTION
```
    @Test
    public void test() {
        Map<String, Object> data = new HashMap<>();
        data.put("login", "email_login");

        MainPage page = new MainPage(new FirefoxDriver());

        page.open();
        page.fillLogin(data);
        Assert.assertEquals(data.get("login"), page.getLogin());
        page.fillLogin(data);
        Assert.assertEquals(data.get("login"), page.getLogin());
    }

    public class MainPage {
        @FindBy(css = "form[role=form]")
        private Form loginForm;

        WebDriver driver;

        public MainPage(WebDriver driver) {
            this.driver = driver;
            PageFactory.initElements(new ElementDecorator(this.driver), this);
        }

        public void open() {
            driver.get("http://www.yandex.ua/");
        }

        public void fillLogin(Map<String, Object> data) {
            loginForm.fill(data);
        }

        public String getLogin() {
            return loginForm.getWrappedElement().findElement(By.cssSelector("[name=login]")).getAttribute("value");
        }
    }