### PR TITLE
Fix for latest Selenium 2.xx 

### DIFF
--- a/htmlelements-java/pom.xml
+++ b/htmlelements-java/pom.xml
@@ -12,7 +12,7 @@
     <name>Yandex QATools HtmlElements For Java</name>
 
     <properties>
-        <selenium.version>2.48.2</selenium.version>
+        <selenium.version>2.53.0</selenium.version>
         <phantomjs-maven-plugin.version>0.7</phantomjs-maven-plugin.version>
         <phantomjs.binary.version>1.9.8</phantomjs.binary.version>
     </properties>
@@ -27,6 +27,11 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.lambdaj</groupId>

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/HtmlElement.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/HtmlElement.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.internal.WrapsElement;
+import org.openqa.selenium.Rectangle;
 
 import java.util.List;
 
@@ -248,6 +249,14 @@ public class HtmlElement implements WebElement, WrapsElement, Named {
     @Override
     public Dimension getSize() {
         return wrappedElement.getSize();
+    }
+
+    /**
+     * @return The location and size of the rendered element
+     */
+    @Override
+    public Rectangle getRect() {
+        return wrappedElement.getRect();
     }
 
     /**


### PR DESCRIPTION
Selenium 2.53.0 dependency. 
```getRect``` implementation in ```HtmlElement```.

@artkoshelev 