### PR TITLE
Expect StaleElementReferenceException on getText

### DIFF
--- a/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/StaleElementReferenceTest.java
+++ b/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/StaleElementReferenceTest.java
@@ -21,7 +21,7 @@ public class StaleElementReferenceTest {
     public void testOutput() {
         StaleElementReferencePage staleElementReferencePage = new StaleElementReferencePage();
         thrown.expect(StaleElementReferenceException.class);
-        assertThat(staleElementReferencePage.getElement().getText(), equalTo(StaleElementReferencePage.ELEMENT_TEXT));
+        staleElementReferencePage.getElement().getText();
     }
 
 }

--- a/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/StaleElementReferenceTest.java
+++ b/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/StaleElementReferenceTest.java
@@ -1,6 +1,9 @@
 package ru.yandex.qatools.htmlelements;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openqa.selenium.StaleElementReferenceException;
 import ru.yandex.qatools.htmlelements.testpages.StaleElementReferencePage;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -11,9 +14,13 @@ import static org.junit.Assert.assertThat;
  */
 public class StaleElementReferenceTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void testOutput() {
         StaleElementReferencePage staleElementReferencePage = new StaleElementReferencePage();
+        thrown.expect(StaleElementReferenceException.class);
         assertThat(staleElementReferencePage.getElement().getText(), equalTo(StaleElementReferencePage.ELEMENT_TEXT));
     }
 

--- a/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/testpages/StaleElementReferencePage.java
+++ b/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/testpages/StaleElementReferencePage.java
@@ -17,8 +17,6 @@ public class StaleElementReferencePage {
 
     public static final String ELEMENT_XPATH = "//div";
 
-    public static final String ELEMENT_TEXT = "element text";
-
     @FindBy(xpath = ELEMENT_XPATH)
     private WebElement element;
 
@@ -40,9 +38,7 @@ public class StaleElementReferencePage {
         WebElement element = mock(WebElement.class);
 
         when(element.getText())
-                .thenThrow(new StaleElementReferenceException("first"))
-                .thenThrow(new StaleElementReferenceException("second"))
-                .thenReturn(ELEMENT_TEXT);
+                .thenThrow(new StaleElementReferenceException("Trying to access stale element"));
 
         when(driver.findElement(By.xpath(ELEMENT_XPATH))).thenReturn(element);
         return driver;


### PR DESCRIPTION
This test always fails. Seems missed exception expectation. Now we expect it.