### PR TITLE
Prevent NullPointerException when webdriver.timeouts.implicitlywait=0

### DIFF
--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/loader/decorator/proxyhandlers/WebElementNamedProxyHandler.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/loader/decorator/proxyhandlers/WebElementNamedProxyHandler.java
@@ -36,18 +36,18 @@ public class WebElementNamedProxyHandler extends LocatingElementHandler {
             return name;
         }
 
-        long end = this.clock.laterBy(TimeUnit.SECONDS.toMillis(this.timeOutInSeconds));
+        final long end = this.clock.laterBy(TimeUnit.SECONDS.toMillis(this.timeOutInSeconds));
 
-        StaleElementReferenceException lasException = null;
-        while (this.clock.isNowBefore(end)) {
+        StaleElementReferenceException lastException;
+        do {
             try {
                 return super.invoke(o, method, objects);
             } catch (StaleElementReferenceException e) {
-                lasException = e;
+                lastException = e;
                 this.waitFor();
             }
-        }
-        throw lasException;
+        } while (this.clock.isNowBefore(end));
+        throw lastException;
     }
 
     protected long sleepFor() {

--- a/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/HtmlElementLocatorTimeoutTest.java
+++ b/htmlelements-java/src/test/java/ru/yandex/qatools/htmlelements/HtmlElementLocatorTimeoutTest.java
@@ -44,7 +44,17 @@ public class HtmlElementLocatorTimeoutTest {
 
     @Test
     public void timeoutWithSystemProperty() {
-        System.setProperty("webdriver.timeouts.implicitlywait", "1");
-        Assert.assertEquals(1, factory.getTimeOut(HtmlElement.class));
+        final String propertyName = "webdriver.timeouts.implicitlywait";
+        final String previousTimeout = System.getProperty(propertyName);
+        System.setProperty(propertyName, "1");
+        try {
+            Assert.assertEquals(1, factory.getTimeOut(HtmlElement.class));
+        } finally {
+            if (previousTimeout == null) {
+                System.getProperties().remove(propertyName);
+            } else {
+                System.setProperty(propertyName, previousTimeout);
+            }
+        }
     }
 }


### PR DESCRIPTION
I don't want to implicitly wait for some element to appear on the page. So I set `-Dwebdriver.timeouts.implicitlywait=0` and get
```
java.lang.NullPointerException
	at ru.yandex.qatools.htmlelements.loader.decorator.proxyhandlers.WebElementNamedProxyHandler.invoke(WebElementNamedProxyHandler.java:50)
	at com.sun.proxy.$Proxy43.isDisplayed(Unknown Source)
	at ru.yandex.qatools.htmlelements.element.HtmlElement.exists(HtmlElement.java:98)

```

After this change method should be invoked at least ones.

Also fixed a typo `lasException` -> `lastException`.

Also fixed a test. Test order is random and depends on JVM,  I got a failed test because another test changed `webdriver.timeouts.implicitlywait` property value and didn't restore it.