### PR TITLE
fix: Table.getRows() is affected by implicit timeout

### DIFF
--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Table.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Table.java
@@ -58,10 +58,9 @@ public class Table extends TypifiedElement {
      */
     public List<List<WebElement>> getRows() {
         return getWrappedElement()
-                .findElements(By.xpath(".//tr"))
+                .findElements(By.xpath(".//tr[.//td]")) // find elements with td tag only
                 .stream()
                 .map(rowElement -> rowElement.findElements(By.xpath(".//td")))
-                .filter(row -> row.size() > 0) // ignore rows with no <td> tags
                 .collect(toList());
     }
 


### PR DESCRIPTION
Rows without 'td' tags, affected by webdriver implicit timeout. To prevent this, xpath was used, which finds only rows with 'td' tags.