### PR TITLE
Form: add possibility to extend form with custom elements

### DIFF
--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/CheckBox.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/CheckBox.java
@@ -10,7 +10,7 @@ import org.openqa.selenium.WebElement;
  * @author Artem Koshelev artkoshelev@yandex-team.ru
  * @author Alexander Tolmachev starlight@yandex-team.ru
  */
-public class CheckBox extends TypifiedElement {
+public class CheckBox extends TypifiedElement implements Fillable {
     /**
      * Specifies wrapped {@link WebElement}.
      *
@@ -79,5 +79,10 @@ public class CheckBox extends TypifiedElement {
         } else {
             deselect();
         }
+    }
+
+    @Override
+    public void fill(String value) {
+        set(Boolean.parseBoolean(value));
     }
 }

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/FileInput.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/FileInput.java
@@ -15,7 +15,7 @@ import static ru.yandex.qatools.htmlelements.utils.HtmlElementUtils.*;
  * @author Alexander Tolmachev starlight@yandex-team.ru
  *         Date: 11.04.13
  */
-public class FileInput extends TypifiedElement {
+public class FileInput extends TypifiedElement implements Fillable {
     /**
      * Specifies wrapped {@link WebElement}.
      *
@@ -73,5 +73,10 @@ public class FileInput extends TypifiedElement {
     private String getPathForSystemFile(final String fileName) {
         File file = new File(fileName);
         return file.getPath();
+    }
+
+    @Override
+    public void fill(String value) {
+        setFileToUpload(value);
     }
 }

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Fillable.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Fillable.java
@@ -1,0 +1,5 @@
+package ru.yandex.qatools.htmlelements.element;
+
+public interface Fillable {
+    void fill(String value);
+}

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Form.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Form.java
@@ -1,122 +1,67 @@
 package ru.yandex.qatools.htmlelements.element;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import java.util.AbstractMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import static java.util.Objects.isNull;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * Represents web page form tag.
- * Provides handy way of filling form with data and submitting it.
+ * Represents default web page form tag.
  *
  * @author Artem Eroshenko eroshenkoam@yandex-team.ru
- *         3/14/13, 4:38 PM
+ * 3/14/13, 4:38 PM
  * @author Alexander Tolmachev starlight@yandex-team.ru
- *         Date: 26.03.13
+ * Date: 26.03.13
+ * @author Dzmitry Sankouski sankouski.dzmitry@gmail.com
+ * Date: 05.03.2020
  */
-public class Form extends TypifiedElement {
-    private static final String CHECKBOX_FIELD = "checkbox";
-    private static final String RADIO_FIELD = "radio";
-    private static final String SELECT_FIELD = "select";
-    private static final String INPUT_FIELD = "input";
-    private static final String FILE_FIELD = "file";
-
+public class Form extends FormBase {
     /**
-     * Specifies {@link org.openqa.selenium.WebElement} representing form tag.
-     *
-     * @param wrappedElement {@code WebElement} to wrap.
-     */
+     * Fillable operations definition
+     * */
+    private static List<FillableOps> fillableOpsList = Arrays.asList(
+            new FillableOps(
+                    CheckBox::new,
+                    element -> {
+                        String tagName = element.getTagName();
+                        String type = element.getAttribute("type");
+                        return "input".equals(tagName) && "checkbox".equals(type);
+                    }),
+            new FillableOps(
+                    Radio::new,
+                    element -> {
+                        String tagName = element.getTagName();
+                        String type = element.getAttribute("type");
+                        return "input".equals(tagName) && "radio".equals(type);
+                    }),
+            new FillableOps(
+                    FileInput::new,
+                    element -> {
+                        String tagName = element.getTagName();
+                        String type = element.getAttribute("type");
+                        return "input".equals(tagName) && "file".equals(type);
+                    }),
+            new FillableOps(
+                    Select::new,
+                    element -> {
+                        String tagName = element.getTagName();
+                        return "select".equals(tagName);
+                    }),
+            new FillableOps(
+                    TextInput::new,
+                    element -> {
+                        String tagName = element.getTagName();
+                        return "input".equals(tagName) || "textarea".equals(tagName);
+                    })
+    );
+
     public Form(WebElement wrappedElement) {
-        super(wrappedElement);
+        super(wrappedElement, fillableOpsList);
     }
 
-    /**
-     * Fills form with data contained in passed map.
-     * For each map entry if an input with a name coincident with entry key exists
-     * it is filled with string representation of entry value.
-     * If an input with such a name is not found the corresponding entry is skipped.
-     *
-     * @param data Map containing data to fill form inputs with.
-     */
-    public void fill(Map<String, Object> data) {
-        data.entrySet().stream()
-                .map(e -> new AbstractMap.SimpleEntry<>(
-                        findElementByKey(e.getKey()),
-                        Objects.toString(e.getValue(), "")))
-                .filter(e -> !isNull(e.getKey()))
-                .forEach(e -> fillElement(e.getKey(), e.getValue()));
-    }
-
-    protected WebElement findElementByKey(String key) {
-        List<WebElement> elements = getWrappedElement().findElements(By.name(key));
-        if (elements.isEmpty()) {
-            return null;
-        } else {
-            return elements.get(0);
-        }
-    }
-
-    protected void fillElement(WebElement element, String value) {
-        String elementType = getElementType(element);
-
-        if (CHECKBOX_FIELD.equals(elementType)) {
-            fillCheckBox(element, value);
-        } else if (RADIO_FIELD.equals(elementType)) {
-            fillRadio(element, value);
-        } else if (INPUT_FIELD.equals(elementType)) {
-            fillInput(element, value);
-        } else if (SELECT_FIELD.equals(elementType)) {
-            fillSelect(element, value);
-        } else if (FILE_FIELD.equals(elementType)) {
-            fillFile(element, value);
-        }
-    }
-
-    protected String getElementType(WebElement element) {
-        String tagName = element.getTagName();
-        if ("input".equals(tagName)) {
-            String type = element.getAttribute("type");
-            if ("checkbox".equals(type)) {
-                return CHECKBOX_FIELD;
-            } else if ("radio".equals(type)) {
-                return RADIO_FIELD;
-            } else if ("file".equals(type)) {
-                return FILE_FIELD;
-            } else {
-                return INPUT_FIELD;
-            }
-        } else if ("select".equals(tagName)) {
-            return SELECT_FIELD;
-        } else if ("textarea".equals(tagName)) {
-            return INPUT_FIELD;
-        } else {
-            return null;
-        }
-    }
-
-    protected void fillCheckBox(WebElement element, String value) {
-        new CheckBox(element).set(Boolean.parseBoolean(value));
-    }
-
-    protected void fillRadio(WebElement element, String value) {
-        new Radio(element).selectByValue(value);
-    }
-
-    protected void fillInput(WebElement element, String value) {
-        TextInput input = new TextInput(element);
-        input.sendKeys(input.getClearCharSequence() + value);
-    }
-
-    protected void fillSelect(WebElement element, String value) {
-        new Select(element).selectByValue(value);
-    }
-
-    protected void fillFile(WebElement element, String value) {
-        new FileInput(element).setFileToUpload(value);
+    public Form(WebElement wrappedElement, List<FillableOps> additionalElements) {
+        super(wrappedElement, Stream.concat(
+                additionalElements.stream(), fillableOpsList.stream()).collect(Collectors.toList()));
     }
 }

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/FormBase.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/FormBase.java
@@ -1,0 +1,102 @@
+package ru.yandex.qatools.htmlelements.element;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Represents web page form tag.
+ * Provides handy way of filling form with data and submitting it.
+ * <p>
+ * Form use {@link Fillable} elements, to perform filling.
+ * You should extend this class and define operations for {@link Fillable} you want to use.
+ *
+ * @author Artem Eroshenko eroshenkoam@yandex-team.ru
+ * 3/14/13, 4:38 PM
+ * @author Alexander Tolmachev starlight@yandex-team.ru
+ * Date: 26.03.13
+ * @author Dzmitry Sankouski sankouski.dzmitry@gmail.com
+ * Date: 05.03.2020
+ */
+public abstract class FormBase extends TypifiedElement {
+    /**
+     * Operations for supported fillable types
+     */
+    private List<FillableOps> fillableOpsList;
+
+    /**
+     * Specifies {@link org.openqa.selenium.WebElement} representing form tag.
+     *
+     * @param wrappedElement {@code WebElement} to wrap.
+     * @param fillableOpsList Fillable operations to register. See {@link FillableOps#FillableOps(Function, Predicate)}
+     *                        Order is important, because {@link #fill(Map)} finds first fillable it can fill.
+     */
+    public FormBase(WebElement wrappedElement, List<FillableOps> fillableOpsList) {
+        super(wrappedElement);
+        this.fillableOpsList = fillableOpsList;
+    }
+
+    /**
+     * Fills form with data contained in passed map.
+     * For each map entry if an input with a name coincident with entry key exists
+     * it is filled with string representation of entry value.
+     * If an input with such a name is not found the corresponding entry is skipped.
+     *
+     * @param data Map containing data to fill form inputs with.
+     */
+    public void fill(Map<String, Object> data) {
+        data.entrySet().stream()
+                .map(e -> new AbstractMap.SimpleEntry<>(
+                        findElementByKey(e.getKey()),
+                        Objects.toString(e.getValue(), "")))
+                .filter(e -> !isNull(e.getKey()))
+                /* Convert WebElement to supported Fillable */
+                .map(elementEntry -> new AbstractMap.SimpleEntry<>(
+                        fillableOpsList.stream()
+                                .filter(supportedFillable -> supportedFillable.getCanFill().test(elementEntry.getKey()))
+                                .map(supportedFillable -> supportedFillable.getWrapIntoFillable().apply(elementEntry.getKey()))
+                                .findFirst()
+                                .orElse(null),
+                        elementEntry.getValue()
+                ))
+                .filter(e -> !isNull(e.getKey()))
+                .forEach(e -> e.getKey().fill(e.getValue()));
+    }
+
+    protected WebElement findElementByKey(String key) {
+        List<WebElement> elements = getWrappedElement().findElements(By.name(key));
+        if (elements.isEmpty()) {
+            return null;
+        } else {
+            return elements.get(0);
+        }
+    }
+
+    protected static class FillableOps {
+        private Function<WebElement, Fillable> wrapIntoFillable;
+        private Predicate<WebElement> canFill;
+
+        /**
+         * To add custom {@link Fillable} element support, add entry with
+         * @param wrapIntoFillable Function to create Fillable from instance of {@link WebElement}
+         * @param canFill Predicate to test, if instance of {@link WebElement} can be represented by this Fillable
+         * */
+        public FillableOps(Function<WebElement, Fillable> wrapIntoFillable, Predicate<WebElement> canFill) {
+            this.wrapIntoFillable = wrapIntoFillable;
+            this.canFill = canFill;
+        }
+
+        public Function<WebElement, Fillable> getWrapIntoFillable() {
+            return wrapIntoFillable;
+        }
+
+        public Predicate<WebElement> getCanFill() {
+            return canFill;
+        }
+    }
+}

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Radio.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Radio.java
@@ -12,7 +12,7 @@ import java.util.List;
  * @author Alexander Tolmachev starlight@yandex-team.ru
  *         Date: 14.08.12
  */
-public class Radio extends TypifiedElement {
+public class Radio extends TypifiedElement implements Fillable {
     /**
      * Specifies a radio button of a radio button group that will be used to find all other buttons of this group.
      *
@@ -105,5 +105,10 @@ public class Radio extends TypifiedElement {
         if (!button.isSelected()) {
             button.click();
         }
+    }
+
+    @Override
+    public void fill(String value) {
+        selectByValue(value);
     }
 }

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Select.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/Select.java
@@ -14,7 +14,7 @@ import java.util.List;
  * @author Artem Koshelev artkoshelev@yandex-team.ru
  * @author Alexander Tolmachev starlight@yandex-team.ru
  */
-public class Select extends TypifiedElement {
+public class Select extends TypifiedElement implements Fillable {
     /**
      * Specifies wrapped {@link WebElement}.
      * Performs no checks unlike {@link org.openqa.selenium.support.ui.Select}. All checks are made later
@@ -156,5 +156,10 @@ public class Select extends TypifiedElement {
      */
     public void deselectByVisibleText(String text) {
         getSelect().deselectByVisibleText(text);
+    }
+
+    @Override
+    public void fill(String value) {
+        selectByValue(value);
     }
 }

--- a/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/TextInput.java
+++ b/htmlelements-java/src/main/java/ru/yandex/qatools/htmlelements/element/TextInput.java
@@ -12,7 +12,7 @@ import java.util.Optional;
  * @author Alexander Tolmachev starlight@yandex-team.ru
  *         Date: 13.08.12
  */
-public class TextInput extends TypifiedElement {
+public class TextInput extends TypifiedElement implements Fillable {
     /**
      * Specifies wrapped {@link WebElement}.
      *
@@ -54,5 +54,10 @@ public class TextInput extends TypifiedElement {
      */
     public String getClearCharSequence() {
         return StringUtils.repeat(Keys.DELETE.toString() + Keys.BACK_SPACE, getText().length());
+    }
+
+    @Override
+    public void fill(String value) {
+        sendKeys(getClearCharSequence() + value);
     }
 }


### PR DESCRIPTION
There can be custom html elements in html form in some applications (for example, custom autocomplete fields).

User is able fill forms with custom html elements, by extending Form class and providing operations for custom elements in constructor.